### PR TITLE
Let's do a bit less tracking and preserve visitors privacy

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -68,7 +68,7 @@ twitter_tweet_button: false
 twitter_follow_button: false
 
 # Google Analytics
-google_analytics_tracking_id: UA-3152571-1
+# google_analytics_tracking_id:
 
 # Facebook Like
 facebook_like: false

--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@
 title: chester's blog
 email: cd@pobox.com
 author: Chester (Carlos Duarte do Nascimento)
-simple_search: //google.com/search
+simple_search: //duckduckgo.com
 subscribe_rss: http://feeds.feedburner.com/chesterbr
 #description: >- # this means to ignore newlines until "baseurl:"
 #  technology, travel, comics, books, math, web, software and random thoughts

--- a/_config.yml
+++ b/_config.yml
@@ -73,9 +73,6 @@ google_analytics_tracking_id: UA-3152571-1
 # Facebook Like
 facebook_like: false
 
-# Custom
-fb_app_id: 248802565130842
-
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list
 # to override the default setting.

--- a/_includes/custom/head.html
+++ b/_includes/custom/head.html
@@ -23,5 +23,3 @@
 <meta property="og:url" content="{{ canonical }}"/>
 <meta property="og:site_name" content="{{ site.title }}"/>
 <meta property="og:description" content="{{ description | strip_html | condense_spaces | truncate:150 }}"/>
-
-<meta property="fb:app_id" content="{{ site.fb_app_id }}" />

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -7,7 +7,7 @@
   {% if site.simple_search %}
 <form action="{{ site.simple_search }}" method="get">
   <fieldset role="search">
-    <input type="hidden" name="sitesearch" value="{{ site.url | shorthand_url }}" />
+    <input type="hidden" name="sites" value="{{ site.url | shorthand_url }}" />
     <input class="search" type="text" name="q" results="0" placeholder="Search"/>
   </fieldset>
 </form>


### PR DESCRIPTION
- Remove Google Analytics (which I never check anyway)
- Switch in-site searches to DuckDuckGo
- Remove Facebook site ID (not sure if that *tracks* anything, but it's kind of useless anyway).

In theory we still have Twitter (which doesn't seem to have privacy issues) and Disqus's social media buttons (but as far as I could verify they are just form-building buttons), but it's an improvement.